### PR TITLE
Media queries + window.matchMedia()

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -13,20 +13,20 @@ class App extends React.Component {
   }
 
   render () {
-    var breakpointColumnsObj = {
-      default: 4,
-      1100: 3,
-      700: 2,
-      500: 1
-    };
+    var breakpointCols = [
+      [1, '(max-width: 500px)'],
+      [2, '(max-width: 700px)'],
+      [3, '(max-width: 1100px)'],
+      [4, '(min-width: 1101px)'],
+    ];
 
     return (
       <div>
         <Masonry
-          breakpointCols={breakpointColumnsObj}
+          breakpointCols={breakpointCols}
           className="my-masonry-grid"
           columnClassName="my-masonry-grid_column"
-          >
+        >
           <div>Item #1z</div>
           <div>Item #2</div>
         </Masonry>

--- a/lib/ReactMasonry.js
+++ b/lib/ReactMasonry.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 
 
 const propTypes = {
-  breakpointCols: PropTypes.object,
+  breakpointCols: PropTypes.array,
   columnClassName: PropTypes.string,
 };
 
 const defaultProps = {
-  breakpointCols: {},
+  breakpointCols: [],
   columnClassName: null
 };
 
@@ -42,19 +42,18 @@ class Masonry extends React.Component {
   }
 
   reCalculateColumnCount() {
-    const windowWidth = (window ? window.innerWidth : null) || Infinity;
-    const breakpointColsObject = this.props.breakpointCols || {};
-    let matchedBreakpoint = Infinity;
-    let columns = Math.max(1, breakpointColsObject.default || 2);
+    const { breakpointCols } = this.props;
+    const defaultNumCols = 2; // TODO: maybe make this a prop?
 
-    for(let breakpoint in breakpointColsObject) {
-      const optBreakpoint = parseInt(breakpoint);
-      const isMaybeCurrentBreakpoint = windowWidth <= optBreakpoint && optBreakpoint < matchedBreakpoint;
-
-      if(optBreakpoint > 0 && isMaybeCurrentBreakpoint) {
-        matchedBreakpoint = optBreakpoint;
-        columns = Math.max(1, breakpointColsObject[breakpoint]);
-      }
+    // take the first breakpoint that matches,
+    // otherwise use default value
+    let columns = defaultNumCols;
+    for (const breakpoint of breakpointCols) {
+    	const [numCols, query] = breakpoint;
+    	if (window.matchMedia(query).matches) {
+    		columns = numCols;
+    		break;
+    	}
     }
 
     if(columns !== this.state.columnCount) {

--- a/lib/ReactMasonry.js
+++ b/lib/ReactMasonry.js
@@ -49,11 +49,11 @@ class Masonry extends React.Component {
     // otherwise use default value
     let columns = defaultNumCols;
     for (const breakpoint of breakpointCols) {
-    	const [numCols, query] = breakpoint;
-    	if (window.matchMedia(query).matches) {
-    		columns = numCols;
-    		break;
-    	}
+      const [numCols, query] = breakpoint;
+      if (window.matchMedia(query).matches) {
+        columns = numCols;
+        break;
+      }
     }
 
     if(columns !== this.state.columnCount) {


### PR DESCRIPTION
being able to specify media queries (rather than window width in pixels) makes it a bit more flexible, I think.

see: https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia