### PR TITLE
Fix react peer dependency issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/paulcollett/react-masonry-css#readme",
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">=16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
It gives an error when trying to install with react 17, had to add `--force` flag in order to force the installation.

Changed to at least v16. Works fine with react 17, just tested.