### PR TITLE
Add option for responsiveness based on element width

### DIFF
--- a/demo/demo.built.js
+++ b/demo/demo.built.js
@@ -8520,9 +8520,13 @@
 
 	  if (Object.getOwnPropertySymbols) {
 	    var symbols = Object.getOwnPropertySymbols(object);
-	    if (enumerableOnly) symbols = symbols.filter(function (sym) {
-	      return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-	    });
+
+	    if (enumerableOnly) {
+	      symbols = symbols.filter(function (sym) {
+	        return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+	      });
+	    }
+
 	    keys.push.apply(keys, symbols);
 	  }
 
@@ -8578,6 +8582,8 @@
 	  // ...any other attribute, will be added to the container
 	  columnAttrs: undefined,
 	  // object, added to the columns
+	  // Whether to use the element width for responsiveness calculations.
+	  elementResponsive: false,
 	  // Deprecated props
 	  // The column property is deprecated.
 	  // It is an alias of the `columnAttrs` property
@@ -8590,7 +8596,9 @@
 	    super(props); // Correct scope for when methods are accessed externally
 
 	    this.reCalculateColumnCount = this.reCalculateColumnCount.bind(this);
-	    this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // default state
+	    this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // Refs
+
+	    this.elementRef = React__default['default'].createRef(); // default state
 
 	    let columnCount;
 
@@ -8641,7 +8649,7 @@
 	  }
 
 	  reCalculateColumnCount() {
-	    const windowWidth = window && window.innerWidth || Infinity;
+	    const width = this.props.elementResponsive ? this.elementRef.current.offsetWidth : window && window.innerWidth || Infinity;
 	    let breakpointColsObject = this.props.breakpointCols; // Allow passing a single number to `breakpointCols` instead of an object
 
 	    if (typeof breakpointColsObject !== 'object') {
@@ -8655,7 +8663,7 @@
 
 	    for (let breakpoint in breakpointColsObject) {
 	      const optBreakpoint = parseInt(breakpoint);
-	      const isCurrentBreakpoint = optBreakpoint > 0 && windowWidth <= optBreakpoint;
+	      const isCurrentBreakpoint = optBreakpoint > 0 && width <= optBreakpoint;
 
 	      if (isCurrentBreakpoint && optBreakpoint < matchedBreakpoint) {
 	        matchedBreakpoint = optBreakpoint;
@@ -8752,7 +8760,8 @@
 	    }
 
 	    return /*#__PURE__*/React__default['default'].createElement("div", _extends({}, rest, {
-	      className: classNameOutput
+	      className: classNameOutput,
+	      ref: this.elementRef
 	    }), this.renderColumns());
 	  }
 

--- a/demo/demo.built.js
+++ b/demo/demo.built.js
@@ -8744,10 +8744,11 @@
 	      columnClassName,
 	      columnAttrs,
 	      column,
+	      elementResponsive,
 	      // used
 	      className
 	    } = _this$props,
-	          rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "className"]);
+	          rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "elementResponsive", "className"]);
 
 	    let classNameOutput = className;
 

--- a/dist/react-masonry-css.cjs.js
+++ b/dist/react-masonry-css.cjs.js
@@ -193,10 +193,11 @@ class Masonry extends React__default['default'].Component {
       columnClassName,
       columnAttrs,
       column,
+      elementResponsive,
       // used
       className
     } = _this$props,
-          rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "className"]);
+          rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "elementResponsive", "className"]);
 
     let classNameOutput = className;
 

--- a/dist/react-masonry-css.cjs.js
+++ b/dist/react-masonry-css.cjs.js
@@ -12,7 +12,7 @@ function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) r
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -31,6 +31,8 @@ const defaultProps = {
   // ...any other attribute, will be added to the container
   columnAttrs: undefined,
   // object, added to the columns
+  // Whether to use the element width for responsiveness calculations.
+  elementResponsive: false,
   // Deprecated props
   // The column property is deprecated.
   // It is an alias of the `columnAttrs` property
@@ -43,7 +45,9 @@ class Masonry extends React__default['default'].Component {
     super(props); // Correct scope for when methods are accessed externally
 
     this.reCalculateColumnCount = this.reCalculateColumnCount.bind(this);
-    this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // default state
+    this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // Refs
+
+    this.elementRef = React__default['default'].createRef(); // default state
 
     let columnCount;
 
@@ -94,7 +98,7 @@ class Masonry extends React__default['default'].Component {
   }
 
   reCalculateColumnCount() {
-    const windowWidth = window && window.innerWidth || Infinity;
+    const width = this.props.elementResponsive ? this.elementRef.current.offsetWidth : window && window.innerWidth || Infinity;
     let breakpointColsObject = this.props.breakpointCols; // Allow passing a single number to `breakpointCols` instead of an object
 
     if (typeof breakpointColsObject !== 'object') {
@@ -108,7 +112,7 @@ class Masonry extends React__default['default'].Component {
 
     for (let breakpoint in breakpointColsObject) {
       const optBreakpoint = parseInt(breakpoint);
-      const isCurrentBreakpoint = optBreakpoint > 0 && windowWidth <= optBreakpoint;
+      const isCurrentBreakpoint = optBreakpoint > 0 && width <= optBreakpoint;
 
       if (isCurrentBreakpoint && optBreakpoint < matchedBreakpoint) {
         matchedBreakpoint = optBreakpoint;
@@ -205,7 +209,8 @@ class Masonry extends React__default['default'].Component {
     }
 
     return /*#__PURE__*/React__default['default'].createElement("div", _extends({}, rest, {
-      className: classNameOutput
+      className: classNameOutput,
+      ref: this.elementRef
     }), this.renderColumns());
   }
 

--- a/dist/react-masonry-css.module.js
+++ b/dist/react-masonry-css.module.js
@@ -187,10 +187,11 @@ class Masonry extends React.Component {
       columnClassName,
       columnAttrs,
       column,
+      elementResponsive,
       // used
       className
     } = _this$props,
-          rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "className"]);
+          rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "elementResponsive", "className"]);
 
     let classNameOutput = className;
 

--- a/dist/react-masonry-css.module.js
+++ b/dist/react-masonry-css.module.js
@@ -6,7 +6,7 @@ function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) r
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
 function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -25,6 +25,8 @@ const defaultProps = {
   // ...any other attribute, will be added to the container
   columnAttrs: undefined,
   // object, added to the columns
+  // Whether to use the element width for responsiveness calculations.
+  elementResponsive: false,
   // Deprecated props
   // The column property is deprecated.
   // It is an alias of the `columnAttrs` property
@@ -37,7 +39,9 @@ class Masonry extends React.Component {
     super(props); // Correct scope for when methods are accessed externally
 
     this.reCalculateColumnCount = this.reCalculateColumnCount.bind(this);
-    this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // default state
+    this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // Refs
+
+    this.elementRef = React.createRef(); // default state
 
     let columnCount;
 
@@ -88,7 +92,7 @@ class Masonry extends React.Component {
   }
 
   reCalculateColumnCount() {
-    const windowWidth = window && window.innerWidth || Infinity;
+    const width = this.props.elementResponsive ? this.elementRef.current.offsetWidth : window && window.innerWidth || Infinity;
     let breakpointColsObject = this.props.breakpointCols; // Allow passing a single number to `breakpointCols` instead of an object
 
     if (typeof breakpointColsObject !== 'object') {
@@ -102,7 +106,7 @@ class Masonry extends React.Component {
 
     for (let breakpoint in breakpointColsObject) {
       const optBreakpoint = parseInt(breakpoint);
-      const isCurrentBreakpoint = optBreakpoint > 0 && windowWidth <= optBreakpoint;
+      const isCurrentBreakpoint = optBreakpoint > 0 && width <= optBreakpoint;
 
       if (isCurrentBreakpoint && optBreakpoint < matchedBreakpoint) {
         matchedBreakpoint = optBreakpoint;
@@ -199,7 +203,8 @@ class Masonry extends React.Component {
     }
 
     return /*#__PURE__*/React.createElement("div", _extends({}, rest, {
-      className: classNameOutput
+      className: classNameOutput,
+      ref: this.elementRef
     }), this.renderColumns());
   }
 

--- a/dist/react-masonry-css.umd.js
+++ b/dist/react-masonry-css.umd.js
@@ -195,10 +195,11 @@
         columnClassName,
         columnAttrs,
         column,
+        elementResponsive,
         // used
         className
       } = _this$props,
-            rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "className"]);
+            rest = _objectWithoutProperties(_this$props, ["children", "breakpointCols", "columnClassName", "columnAttrs", "column", "elementResponsive", "className"]);
 
       let classNameOutput = className;
 

--- a/dist/react-masonry-css.umd.js
+++ b/dist/react-masonry-css.umd.js
@@ -14,7 +14,7 @@
 
   function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
-  function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+  function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) { symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); } keys.push.apply(keys, symbols); } return keys; }
 
   function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
@@ -33,6 +33,8 @@
     // ...any other attribute, will be added to the container
     columnAttrs: undefined,
     // object, added to the columns
+    // Whether to use the element width for responsiveness calculations.
+    elementResponsive: false,
     // Deprecated props
     // The column property is deprecated.
     // It is an alias of the `columnAttrs` property
@@ -45,7 +47,9 @@
       super(props); // Correct scope for when methods are accessed externally
 
       this.reCalculateColumnCount = this.reCalculateColumnCount.bind(this);
-      this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // default state
+      this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this); // Refs
+
+      this.elementRef = React__default['default'].createRef(); // default state
 
       let columnCount;
 
@@ -96,7 +100,7 @@
     }
 
     reCalculateColumnCount() {
-      const windowWidth = window && window.innerWidth || Infinity;
+      const width = this.props.elementResponsive ? this.elementRef.current.offsetWidth : window && window.innerWidth || Infinity;
       let breakpointColsObject = this.props.breakpointCols; // Allow passing a single number to `breakpointCols` instead of an object
 
       if (typeof breakpointColsObject !== 'object') {
@@ -110,7 +114,7 @@
 
       for (let breakpoint in breakpointColsObject) {
         const optBreakpoint = parseInt(breakpoint);
-        const isCurrentBreakpoint = optBreakpoint > 0 && windowWidth <= optBreakpoint;
+        const isCurrentBreakpoint = optBreakpoint > 0 && width <= optBreakpoint;
 
         if (isCurrentBreakpoint && optBreakpoint < matchedBreakpoint) {
           matchedBreakpoint = optBreakpoint;
@@ -207,7 +211,8 @@
       }
 
       return /*#__PURE__*/React__default['default'].createElement("div", _extends({}, rest, {
-        className: classNameOutput
+        className: classNameOutput,
+        ref: this.elementRef
       }), this.renderColumns());
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export interface MasonryProps {
   breakpointCols?: number | { default: number, [key: number]: number } | { [key: number]: number };
   columnClassName?: string;
   className: string;
+  elementResponsive?: boolean;
 }
 
 export default class Masonry extends React.Component<MasonryProps & React.HTMLProps<HTMLElement>, any> {

--- a/src/react-masonry-css.js
+++ b/src/react-masonry-css.js
@@ -13,6 +13,9 @@ const defaultProps = {
   // ...any other attribute, will be added to the container
   columnAttrs: undefined, // object, added to the columns
 
+  // Whether to use the element width for responsiveness calculations.
+  elementResponsive: false,
+
   // Deprecated props
   // The column property is deprecated.
   // It is an alias of the `columnAttrs` property
@@ -28,6 +31,9 @@ class Masonry extends React.Component {
     // Correct scope for when methods are accessed externally
     this.reCalculateColumnCount = this.reCalculateColumnCount.bind(this);
     this.reCalculateColumnCountDebounce = this.reCalculateColumnCountDebounce.bind(this);
+
+    // Refs
+    this.elementRef = React.createRef();
 
     // default state
     let columnCount
@@ -77,7 +83,10 @@ class Masonry extends React.Component {
   }
 
   reCalculateColumnCount() {
-    const windowWidth = window && window.innerWidth || Infinity;
+    const width = this.props.elementResponsive
+        ? this.elementRef.current.offsetWidth
+        : (window && window.innerWidth || Infinity);
+
     let breakpointColsObject = this.props.breakpointCols;
 
     // Allow passing a single number to `breakpointCols` instead of an object
@@ -92,7 +101,7 @@ class Masonry extends React.Component {
 
     for(let breakpoint in breakpointColsObject) {
       const optBreakpoint = parseInt(breakpoint);
-      const isCurrentBreakpoint = optBreakpoint > 0 && windowWidth <= optBreakpoint;
+      const isCurrentBreakpoint = optBreakpoint > 0 && width <= optBreakpoint;
 
       if(isCurrentBreakpoint && optBreakpoint < matchedBreakpoint) {
         matchedBreakpoint = optBreakpoint;
@@ -201,6 +210,7 @@ class Masonry extends React.Component {
       <div
         {...rest}
         className={classNameOutput}
+        ref={this.elementRef}
       >
         {this.renderColumns()}
       </div>

--- a/src/react-masonry-css.js
+++ b/src/react-masonry-css.js
@@ -188,6 +188,7 @@ class Masonry extends React.Component {
       columnClassName,
       columnAttrs,
       column,
+      elementResponsive,
 
       // used
       className,


### PR DESCRIPTION
Greetings!

Not sure if this is of any use to anyone but I found this to be quite useful in a recent project. Namely, the option to use the width of the container div for the purpose of responsive calculations.

The rationale behind this is that the masonry grid may be on different pages w/ different layouts thereby having a different width which makes creating a "one size fits all" breakpoint rule set difficult.

I don't see this being a breaking change however I am not too familiar with the project.